### PR TITLE
Fix duplicate chat item on logout and login (issue #42)

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -96,6 +96,7 @@ export default {
     logout() {
       // TODO use a better way
       this.$root.$refs.authPopup.openLogout();
+      this.$router.push('/');
     },
   },
   created() {


### PR DESCRIPTION
Possible fix for issue #42
simple fix by clearing the username at the address bar on logout.
I think keeping the username there even after logout doesn't make sense. feel free to merge if you agree.

regards.